### PR TITLE
Added report-level control over which data may be extracted for each project

### DIFF
--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -321,10 +321,10 @@ class BioCatalyst extends AbstractExternalModule
                 (select rr.report_id
                     ,rr.title
                     ,restricted.are_reports_restricted
-                    ,JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as varchar(5)),'\"'),'$') as is_report_allowed
+                    ,JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as char(10)),'\"'),'$') as is_report_allowed
                     ,case 
                         when restricted.are_reports_restricted='no' then '1' 
-                        when restricted.are_reports_restricted='yes' then JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as varchar(5)),'\"'),'$')  
+                        when restricted.are_reports_restricted='yes' then JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as char(10)),'\"'),'$')  
                         else 1 
                     END as do_permit_this_report
                         from redcap_external_modules rem

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -315,8 +315,8 @@ class BioCatalyst extends AbstractExternalModule
         // Get all reports for the specified biocatalyst project, excluding those which are within projects
         // configured to restrict the allowed reports, except those in such projects flagged to be allowed.
         //
-        // NOTE: Projects which do not have a "Restrict reports?" flag set will not permit any reports to export.
-        // This will create a backwards-compatibility problem issue and should be documented and communicated to end users.
+        // NOTE: Projects which do not have a "Restrict reports?" flag set will permit all reports to export.
+
         $sql=   "select report_id,title from 
                 (select rr.report_id
                     ,rr.title
@@ -325,7 +325,7 @@ class BioCatalyst extends AbstractExternalModule
                     ,case 
                         when restricted.are_reports_restricted='no' then '1' 
                         when restricted.are_reports_restricted='yes' then JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as varchar(5)),'\"'),'$')  
-                        else 0 
+                        else 1 
                     END as do_permit_this_report
                         from redcap_external_modules rem
                         left join redcap_external_module_settings rems on rem.external_module_id = rems.external_module_id

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -313,6 +313,8 @@ class BioCatalyst extends AbstractExternalModule
         $reports = array();
 
         // Get all reports for the specified biocatalyst project
+        // Original code (without allow-reports restrictions) below
+        /*
         $sql = "select rr.report_id, rr.title
                 from redcap_external_modules rem
                 left join redcap_external_module_settings rems on rem.external_module_id = rems.external_module_id
@@ -321,7 +323,33 @@ class BioCatalyst extends AbstractExternalModule
                 and rems.key = 'biocatalyst-enabled'
                 and rems.value = 'true'
                 and rr.project_id = " . intval($project_id);
-        $q = $this->query($sql);
+        */
+
+        $sql=   "select report_id,title from 
+                (select rr.report_id
+                    ,rr.title
+                    ,restricted.are_reports_restricted
+                    ,JSON_CONTAINS(bcreports.allowed_reports,CONCAT('"',cast(rr.report_id as varchar(5)),'"'),'$') as is_report_allowed
+                    ,case 
+                        when restricted.are_reports_restricted='no' then '1' 
+                        when restricted.are_reports_restricted='yes' then JSON_CONTAINS(bcreports.allowed_reports,CONCAT('"',cast(rr.report_id as varchar(5)),'"'),'$')  
+                        else 0 
+                    END as do_permit_this_report
+                        from redcap_external_modules rem
+                        left join redcap_external_module_settings rems on rem.external_module_id = rems.external_module_id
+                        left join redcap_reports rr on rems.project_id = rr.project_id
+                        LEFT JOIN (select external_module_id,project_id,value as allowed_reports from redcap_external_module_settings where `key`='allowed_reports' and project_id=" . intval($project_id) . ") as bcreports 
+                            ON rems.project_id=bcreports.project_id and rems.external_module_id=bcreports.external_module_id
+                        LEFT JOIN (select external_module_id,project_id,value as are_reports_restricted from redcap_external_module_settings where `key`='are_reports_restricted' and project_id=" . intval($project_id) . ") as restricted 
+                            ON rems.project_id=bcreports.project_id and rems.external_module_id=bcreports.external_module_id
+                        where rem.directory_prefix = 'biocatalyst_link'
+                        and rems.key = 'biocatalyst-enabled'
+                        and rems.value = 'true'
+                        and rr.project_id = " . intval($project_id) . "
+                    ) as report_list
+                where do_permit_this_report='1'";
+
+                $q = $this->query($sql);
         while ($row = db_fetch_assoc($q)) {
             $reports[] = $row;
         }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Open the Project Config File and select the **Enable Stanford Biocatalyst to acc
 
 ![ProjectConfigFile](images/ProjectConfigFile.png)
 
+To restrict Biocatalyst to be able to access on administrator-selected reports in the project, select "yes" in response to **Should Biocatalyst be limited to access only specific reports?** and enter `report_id` numbers in the **Allowed report** fields that appear.  Select `+` next to the **Allowed report** field to add more than one permitted report.  (*IMPORTANT: If either the "no" option or no response is selected in response to **Should Biocatalyst be limited to access only specific reports?**, all reports in this project will be available to Biocatalyst.*)
+
 Save the configuration.  This project's reports are now accessible from the system-level API endpoints.
 
 ## API Calls and Example Syntax

--- a/config.json
+++ b/config.json
@@ -100,7 +100,7 @@
         },
         {
           "key": "allowed_reports",
-          "name": "Allowed reports",
+          "name": "Allowed report (enter unique report ID nunmber)",
           "type": "text",
           "repeatable": true,
           "branchingLogic": {

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "description": "A module that links redcap projects to Stanford Biocatalyst",
     "versions": [
         {
-            "0.1": "Initial Development Version"
+            "0.2": "Link can be restricted to specific reports in a project"
         }
     ],
     "authors": [

--- a/config.json
+++ b/config.json
@@ -84,7 +84,7 @@
         },
         {
           "key": "are_reports_restricted",
-          "name": "Should Biocatalyst be limited to access only specific reports?",
+          "name": "Should Biocatalyst be limited to access only specific reports?  If not specified, Biocatalyst will be able to extract ALL reports in this project.",
           "required": true,
           "type": "radio",
           "choices": [

--- a/config.json
+++ b/config.json
@@ -1,94 +1,112 @@
 {
-  "name": "Stanford Biocatalyst Link",
-
-  "namespace":"Stanford\\BioCatalyst",
-
-  "description": "A module that links redcap projects to Stanford Biocatalyst",
-
-  "versions": [
-    { "0.1": "Initial Development Version" }
-  ],
-
-  "authors": [
-    {
-      "name": "Andy Martin",
-      "email": "andy123@stanford.edu",
-      "institution": "Stanford University"
-    },
-    {
-      "name": "LeeAnn Yasukawa",
-      "email": "yasukawa@stanford.edu",
-      "institution": "Stanford University"
-    }
-  ],
-
-  "permissions": [
-    "redcap_module_project_enable"
-  ],
-
-  "no-auth-pages": [
-    "service",
-    "BioCatalystReports"
-  ],
-
-  "links": {
-    "control-center": [
-      {
-        "name": "BioCatalyst Instructions",
-        "icon": "gear",
-        "url": "instructions.php"
-      }
-    ],
-    "project": [
-    ]
-  },
-
-  "system-settings": [
-    {
-      "key": "biocatalyst-api-token",
-      "name": "<b>This is the specific API token to be used by BioCatalyst.  This is a shared secret and should be kept secure.",
-      "type": "text",
-      "required": true
-    },
-    {
-      "key": "alert-email",
-      "name": "<b>This is the email address where an alert will be sent when a non white-listed IP is trying to access this endpoint.",
-      "required": true,
-      "type": "text"
-    },
-    {
-      "key": "ip_whitelist",
-      "name": "IP Whitelist",
-      "type": "sub_settings",
-      "repeatable": true,
-      "sub_settings": [
+    "name": "Stanford Biocatalyst Link",
+    "namespace": "Stanford\\BioCatalyst",
+    "description": "A module that links redcap projects to Stanford Biocatalyst",
+    "versions": [
         {
-          "key": "ip",
-          "name": "IP address or CIDR notation (e.g. 192.168.123.1/24). Create a new subsetting for each IP address.",
-          "required": false,
-          "type": "text"
+            "0.1": "Initial Development Version"
         }
-      ]
+    ],
+    "authors": [
+        {
+            "name": "Andy Martin",
+            "email": "andy123@stanford.edu",
+            "institution": "Stanford University"
+        },
+        {
+            "name": "LeeAnn Yasukawa",
+            "email": "yasukawa@stanford.edu",
+            "institution": "Stanford University"
+        }
+    ],
+    "permissions": [
+        "redcap_module_project_enable"
+    ],
+    "no-auth-pages": [
+        "service",
+        "BioCatalystReports"
+    ],
+    "links": {
+        "control-center": [
+            {
+                "name": "BioCatalyst Instructions",
+                "icon": "gear",
+                "url": "instructions.php"
+            }
+        ],
+        "project": []
     },
-    {
-      "key": "enable-system-debug-logging",
-      "name": "<b>Enable Debug Logging (system-wide)</b>",
-      "required": false,
-      "type": "checkbox"
-    }
-  ],
-
-  "project-settings": [
-    {
-      "key": "biocatalyst-enabled",
-      "name": "<b>Enable Stanford Biocatalyst to access reports in this project</b><br/>Only a project admin can enable/disable this feature for a project.  Once enabled, any REDCap user of this project with Data Export rights will be able to access this project's reports from the BioCatalyst application.",
-      "type": "checkbox"
-    },
-    {
-      "key": "enable-project-debug-logging",
-      "name": "<b>Enable Debug Logging</b>",
-      "required": false,
-      "type": "checkbox"
-    }
-  ]
+    "system-settings": [
+        {
+            "key": "biocatalyst-api-token",
+            "name": "<b>This is the specific API token to be used by BioCatalyst.  This is a shared secret and should be kept secure.",
+            "type": "text",
+            "required": true
+        },
+        {
+            "key": "alert-email",
+            "name": "<b>This is the email address where an alert will be sent when a non white-listed IP is trying to access this endpoint.",
+            "required": true,
+            "type": "text"
+        },
+        {
+            "key": "ip_whitelist",
+            "name": "IP Whitelist",
+            "type": "sub_settings",
+            "repeatable": true,
+            "sub_settings": [
+                {
+                    "key": "ip",
+                    "name": "IP address or CIDR notation (e.g. 192.168.123.1/24). Create a new subsetting for each IP address.",
+                    "required": false,
+                    "type": "text"
+                }
+            ]
+        },
+        {
+            "key": "enable-system-debug-logging",
+            "name": "<b>Enable Debug Logging (system-wide)</b>",
+            "required": false,
+            "type": "checkbox"
+        }
+    ],
+    "project-settings": [
+        {
+            "key": "biocatalyst-enabled",
+            "name": "<b>Enable Stanford Biocatalyst to access reports in this project</b><br/>Only a project admin can enable/disable this feature for a project.  Once enabled, any REDCap user of this project with Data Export rights will be able to access this project's reports from the BioCatalyst application.",
+            "type": "checkbox"
+        },
+        {
+            "key": "enable-project-debug-logging",
+            "name": "<b>Enable Debug Logging</b>",
+            "required": false,
+            "type": "checkbox"
+        },
+        {
+          "key": "are_reports_restricted",
+          "name": "Should Biocatalyst be limited to access only specific reports?",
+          "required": true,
+          "type": "radio",
+          "choices": [
+            {
+              "value":"yes",
+              "name":"Yes"
+            },
+            {
+              "value":"no",
+              "name":"No"
+            }
+          ]
+        },
+        {
+          "key": "allowed_reports",
+          "name": "Allowed reports",
+          "type": "text",
+          "repeatable": true,
+          "branchingLogic": {
+            "field": "are_reports_restricted",
+            "value": "yes"
+          }
+        }
+     ]
 }


### PR DESCRIPTION
Added new module settings to permit users to restrict Biocatalyst link to specified reports within a project.  Updated report listing SQL call to add queries into `redcap_external_module_settings` to interrogate against `are_reports_restricted` and `allowed_reports` key/value pairs.  

Projects with `are_reports_restricted` flagged as a "no" permit any reports in the project to be extracted.  If `are_reports_restricted` is flagged as a "yes" then only reports listed in the `allowed_reports` configuration list (a jsonic list, examined using `JSON_CONTAINS`) are included in the list of available reports.  

If the `are_reports_restricted` field is not found, then all reports are made available for extraction.  (This is a change from the comment in commit `43a83239713953b8b1ac1569315b1d2c274521b8`.

Resolves #1 .