### PR TITLE
Prevents data from being exported from reports not listed in the allowed reports list

### DIFF
--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,7 +343,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-        if (count($allowed_reports) == 0 || !! in_array(0,$allowed_reports)) {
+        if (count($allowed_reports) <> 1 || in_array(1,$allowed_reports)) {
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,7 +343,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-        if (count($allowed_reports) <> 1 || $allowed_reports[0]==1)) {
+        if (count($allowed_reports) <> 1 )) {
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,7 +343,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-        if (count($allowed_reports) <> 1 || $allowed_reports[0]==1)) {
+        if (count($allowed_reports) <> 1 || $allowed_reports[0]==1) {
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,11 +343,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-<<<<<<< HEAD
         if (count($allowed_reports) <> 1 || $allowed_reports[0]==1)) {
-=======
-        if (count($allowed_reports) <> 1 || in_array(1,$allowed_reports)) {
->>>>>>> development
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,7 +343,11 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
+<<<<<<< HEAD
+        if (count($allowed_reports) <> 1 || $allowed_reports[0]==1)) {
+=======
         if (count($allowed_reports) <> 1 || in_array(1,$allowed_reports)) {
+>>>>>>> development
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -333,7 +333,8 @@ class BioCatalyst extends AbstractExternalModule
                         and rems.value = 'true'
                         and rr.project_id = " . intval($project_id) . "
                         and rr.report_id = " . intval($report_id) . "
-                    ) as report_list";
+                    ) as report_list
+                WHERE do_permit_this_report='1'";
 
                 $q = $this->query($sql);
         while ($row = db_fetch_assoc($q)) {
@@ -343,7 +344,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-        if (count($allowed_reports) <> 1 || $allowed_reports[0]<>1) {
+        if (count($allowed_reports) < 1) {
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,7 +343,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-        if (count($allowed_reports) <> 1 || $allowed_reports[0]==1) {
+        if (count($allowed_reports) <> 1 || $allowed_reports[0]<>1) {
             return false;
         }
         return true;

--- a/BioCatalyst.php
+++ b/BioCatalyst.php
@@ -343,7 +343,7 @@ class BioCatalyst extends AbstractExternalModule
         // Error if insufficient permissions
 
         
-        if (count($allowed_reports) == 0 || in_array(0,$allowed_reports)) {
+        if (count($allowed_reports) == 0 || !! in_array(0,$allowed_reports)) {
             return false;
         }
         return true;

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "description": "A module that links redcap projects to Stanford Biocatalyst",
     "versions": [
         {
-            "0.2": "Link can be restricted to specific reports in a project"
+            "0.3": "Link restricts data pulls based on allowed reports config for projects"
         }
     ],
     "authors": [

--- a/config.json
+++ b/config.json
@@ -74,19 +74,22 @@
         {
             "key": "biocatalyst-enabled",
             "name": "<b>Enable Stanford Biocatalyst to access reports in this project</b><br/>Only a project admin can enable/disable this feature for a project.  Once enabled, any REDCap user of this project with Data Export rights will be able to access this project's reports from the BioCatalyst application.",
-            "type": "checkbox"
+            "type": "checkbox",
+            "super-users-only": true
         },
         {
             "key": "enable-project-debug-logging",
             "name": "<b>Enable Debug Logging</b>",
             "required": false,
-            "type": "checkbox"
+            "type": "checkbox",
+            "super-users-only": true
         },
         {
           "key": "are_reports_restricted",
           "name": "Should Biocatalyst be limited to access only specific reports?  If not specified, Biocatalyst will be able to extract ALL reports in this project.",
           "required": true,
           "type": "radio",
+          "super-users-only": true,
           "choices": [
             {
               "value":"yes",
@@ -102,6 +105,7 @@
           "key": "allowed_reports",
           "name": "Allowed report (enter unique report ID nunmber)",
           "type": "text",
+          "super-users-only": true,
           "repeatable": true,
           "branchingLogic": {
             "field": "are_reports_restricted",

--- a/tests/is_report_allowed.sql
+++ b/tests/is_report_allowed.sql
@@ -1,0 +1,23 @@
+select do_permit_this_report  from 
+                (select rr.report_id
+                    ,rr.title
+                    ,restricted.are_reports_restricted
+                    ,JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as char(10)),'\"'),'$') as is_report_allowed
+                    ,case 
+                        when restricted.are_reports_restricted='no' then '1' 
+                        when restricted.are_reports_restricted='yes' then JSON_CONTAINS(bcreports.allowed_reports,CONCAT('\"',cast(rr.report_id as char(10)),'\"'),'$')  
+                        else 1 
+                    END as do_permit_this_report
+                        from redcap_external_modules rem
+                        left join redcap_external_module_settings rems on rem.external_module_id = rems.external_module_id
+                        left join redcap_reports rr on rems.project_id = rr.project_id
+                        LEFT JOIN (select external_module_id,project_id,value as allowed_reports from redcap_external_module_settings where `key`='allowed_reports' and project_id=16) as bcreports 
+                            ON rems.project_id=bcreports.project_id and rems.external_module_id=bcreports.external_module_id
+                        LEFT JOIN (select external_module_id,project_id,value as are_reports_restricted from redcap_external_module_settings where `key`='are_reports_restricted' and project_id=16) as restricted 
+                            ON rems.project_id=bcreports.project_id and rems.external_module_id=bcreports.external_module_id
+                        where rem.directory_prefix = 'biocatalyst_link'
+                        and rems.key = 'biocatalyst-enabled'
+                        and rems.value = 'true'
+                        and rr.project_id = 16
+                        and rr.report_id = 6
+                    ) as report_list


### PR DESCRIPTION
The prior version of the codebase (accomodating the fix for #2 implemented by PR2 - `https://github.com/susom/biocatalyst-link/pull/2`) did not enforce data extraction restrictions on a per-report basis.  Thus the Biocatalyst platform could extract data for specific reports by submitting the report_id even if it did not appear in the list returned by `getProjectReports()`.

This PR correctly implements this feature by adding a `verifyReportAllowed()` function to verify that a report is allowed for export.  The SQL embedded in this is modeled from the report list check in `getProjectReports()`.  The `verifyReportAllowed()` function is derived from the `verifyExportRights()` function and should return a true/false for logic tests.

The new function is now implemented in `getReport()` and `getReportColumns()`.

Also updated error message text for calls to `verifyExportRights()` to discriminate between these calls and calls to `verifyReportAllowed()`.